### PR TITLE
Esp32 sd.h

### DIFF
--- a/ESPWebDAV.cpp
+++ b/ESPWebDAV.cpp
@@ -13,7 +13,11 @@
 #else
 #include <SD.h>
 #endif
+#ifdef ESP32
+#include <mbedtls/sha256.h>
+#else
 #include <Hash.h>
+#endif //ESP32
 #include <time.h>
 #include "ESPWebDAV.h"
 
@@ -21,6 +25,12 @@
 const char *months[]  = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
 const char *wdays[]  = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
 
+String sha256(String input) {
+	//TODO: Actually do something useful
+	//unsigned char sha256[32];
+	//mbedtls_sha256_ret((const unsigned char*)input.c_str(), sizeof(input.c_str()), sha256, 0);
+	return input;
+}
 
 // ------------------------
 #ifdef USE_SDFAT
@@ -360,7 +370,11 @@ void ESPWebDAV::handleProp(ResourceType resource)	{
 	sendContent(fileTimeStamp);
 	sendContent(F("</D:getlastmodified><D:getetag>"));
 	// append unique tag generated from full path
+#ifdef ESP32
+	sendContent("\"" + sha256(fullResPath + fileTimeStamp) + "\"");
+#else
 	sendContent("\"" + sha1(fullResPath + fileTimeStamp) + "\"");
+#endif
 	sendContent(F("</D:getetag>"));
 
 #ifdef USE_SDFAT

--- a/ESPWebDAV.cpp
+++ b/ESPWebDAV.cpp
@@ -330,12 +330,12 @@ void ESPWebDAV::handleProp(ResourceType resource)	{
 // String fullResPath = "http://" + hostHeader + uri;
 	String fullResPath = uri;
 
-	if(recursing)
+	if(recursing) {
 		if(fullResPath.endsWith("/"))
 			fullResPath += String(buf);
 		else
 			fullResPath += "/" + String(buf);
-
+	};
 	// get file modified time
 #ifdef USE_SDFAT
 	dir_t dir;

--- a/ESPWebDAV.cpp
+++ b/ESPWebDAV.cpp
@@ -1,7 +1,11 @@
 // WebDAV server using ESP8266 and SD card filesystem
 // Targeting Windows 7 Explorer WebDav
 
+#ifdef ESP32
+#include <WiFi.h>
+#else
 #include <ESP8266WiFi.h>
+#endif
 #include <SPI.h>
 #include <SdFat.h>
 #include <Hash.h>

--- a/ESPWebDAV.h
+++ b/ESPWebDAV.h
@@ -1,4 +1,8 @@
+#ifdef ESP32
+#include <WiFi.h>
+#else
 #include <ESP8266WiFi.h>
+#endif
 #include <SdFat.h>
 
 // debugging

--- a/ESPWebDAV.h
+++ b/ESPWebDAV.h
@@ -3,7 +3,11 @@
 #else
 #include <ESP8266WiFi.h>
 #endif
+#ifdef USE_SDFAT
 #include <SdFat.h>
+#else
+#include <SD.h>
+#endif
 
 // debugging
 // #define DBG_PRINT(...) 		{ Serial.print(__VA_ARGS__); }
@@ -23,7 +27,12 @@ enum DepthType { DEPTH_NONE, DEPTH_CHILD, DEPTH_ALL };
 
 class ESPWebDAV	{
 public:
+#ifdef USE_SDFAT
 	bool init(int chipSelectPin, SPISettings spiSettings, int serverPort);
+#else
+	ESPWebDAV(): sd(SD) {};
+	bool init(int serverPort);
+#endif
 	bool isClientWaiting();
 	void handleClient(String blank = "");
 	void rejectClient(String rejectMessage);
@@ -40,10 +49,18 @@ protected:
 	void handleUnlock(ResourceType resource);
 	void handlePropPatch(ResourceType resource);
 	void handleProp(ResourceType resource);
+#ifdef USE_SDFAT
 	void sendPropResponse(boolean recursing, FatFile *curFile);
+#else
+	void sendPropResponse(boolean recursing, File *curFile);
+#endif
 	void handleGet(ResourceType resource, bool isGet);
 	void handlePut(ResourceType resource);
+#ifdef USE_SDFAT
 	void handleWriteError(String message, FatFile *wFile);
+#else
+	void handleWriteError(String message, File *wFile);
+#endif
 	void handleDirectoryCreate(ResourceType resource);
 	void handleMove(ResourceType resource);
 	void handleDelete(ResourceType resource);
@@ -65,7 +82,11 @@ protected:
 	
 	// variables pertaining to current most HTTP request being serviced
 	WiFiServer *server;
+#ifdef USE_SDFAT
 	SdFat sd;
+#else
+	fs::SDFS sd;
+#endif
 
 	WiFiClient 	client;
 	String 		method;


### PR DESCRIPTION
Allow to run the WebDAV Server on ESP32 without SDFat.h. While SDFat is superior in terms of performance, it is not supported officially on ESP32 and might also interfere with with other parts of a bigger project that is using the vendor SD.h.

This PR adds a the variable `USE_SDFAT`. If it is set, the existing code is used to rely on SDFat.h. In case it is not set the function calls of the vendor SD.h are used.

This is untested on ESP8266 since I have no appropriate hardware at hand.