### PR TITLE
Wrong Name issue when not using USE_SDFAT

### DIFF
--- a/ESPWebDAV.cpp
+++ b/ESPWebDAV.cpp
@@ -13,7 +13,11 @@
 #else
 #include <SD.h>
 #endif
+#ifdef ESP32
+#include <mbedtls/sha256.h>
+#else
 #include <Hash.h>
+#endif //ESP32
 #include <time.h>
 #include "ESPWebDAV.h"
 
@@ -21,6 +25,12 @@
 const char *months[]  = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
 const char *wdays[]  = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
 
+String sha256(String input) {
+	//TODO: Actually do something useful
+	//unsigned char sha256[32];
+	//mbedtls_sha256_ret((const unsigned char*)input.c_str(), sizeof(input.c_str()), sha256, 0);
+	return input;
+}
 
 // ------------------------
 #ifdef USE_SDFAT
@@ -360,7 +370,11 @@ void ESPWebDAV::handleProp(ResourceType resource)	{
 	sendContent(fileTimeStamp);
 	sendContent(F("</D:getlastmodified><D:getetag>"));
 	// append unique tag generated from full path
+#ifdef ESP32
+	sendContent("\"" + sha256(fullResPath + fileTimeStamp) + "\"");
+#else
 	sendContent("\"" + sha1(fullResPath + fileTimeStamp) + "\"");
+#endif
 	sendContent(F("</D:getetag>"));
 
 #ifdef USE_SDFAT

--- a/ESPWebDAV.cpp
+++ b/ESPWebDAV.cpp
@@ -330,12 +330,12 @@ void ESPWebDAV::handleProp(ResourceType resource)	{
 // String fullResPath = "http://" + hostHeader + uri;
 	String fullResPath = uri;
 
-	if(recursing)
+	if(recursing) {
 		if(fullResPath.endsWith("/"))
 			fullResPath += String(buf);
 		else
 			fullResPath += "/" + String(buf);
-
+	};
 	// get file modified time
 #ifdef USE_SDFAT
 	dir_t dir;

--- a/ESPWebDAV.cpp
+++ b/ESPWebDAV.cpp
@@ -1,7 +1,11 @@
 // WebDAV server using ESP8266 and SD card filesystem
 // Targeting Windows 7 Explorer WebDav
 
+#ifdef ESP32
+#include <WiFi.h>
+#else
 #include <ESP8266WiFi.h>
+#endif
 #include <SPI.h>
 #include <SdFat.h>
 #include <Hash.h>

--- a/ESPWebDAV.h
+++ b/ESPWebDAV.h
@@ -1,4 +1,8 @@
+#ifdef ESP32
+#include <WiFi.h>
+#else
 #include <ESP8266WiFi.h>
+#endif
 #include <SdFat.h>
 
 // debugging

--- a/ESPWebDAV.h
+++ b/ESPWebDAV.h
@@ -3,7 +3,11 @@
 #else
 #include <ESP8266WiFi.h>
 #endif
+#ifdef USE_SDFAT
 #include <SdFat.h>
+#else
+#include <SD.h>
+#endif
 
 // debugging
 // #define DBG_PRINT(...) 		{ Serial.print(__VA_ARGS__); }
@@ -23,7 +27,12 @@ enum DepthType { DEPTH_NONE, DEPTH_CHILD, DEPTH_ALL };
 
 class ESPWebDAV	{
 public:
+#ifdef USE_SDFAT
 	bool init(int chipSelectPin, SPISettings spiSettings, int serverPort);
+#else
+	ESPWebDAV(): sd(SD) {};
+	bool init(int serverPort);
+#endif
 	bool isClientWaiting();
 	void handleClient(String blank = "");
 	void rejectClient(String rejectMessage);
@@ -40,10 +49,18 @@ protected:
 	void handleUnlock(ResourceType resource);
 	void handlePropPatch(ResourceType resource);
 	void handleProp(ResourceType resource);
+#ifdef USE_SDFAT
 	void sendPropResponse(boolean recursing, FatFile *curFile);
+#else
+	void sendPropResponse(boolean recursing, File *curFile);
+#endif
 	void handleGet(ResourceType resource, bool isGet);
 	void handlePut(ResourceType resource);
+#ifdef USE_SDFAT
 	void handleWriteError(String message, FatFile *wFile);
+#else
+	void handleWriteError(String message, File *wFile);
+#endif
 	void handleDirectoryCreate(ResourceType resource);
 	void handleMove(ResourceType resource);
 	void handleDelete(ResourceType resource);
@@ -65,7 +82,11 @@ protected:
 	
 	// variables pertaining to current most HTTP request being serviced
 	WiFiServer *server;
+#ifdef USE_SDFAT
 	SdFat sd;
+#else
+	fs::SDFS sd;
+#endif
 
 	WiFiClient 	client;
 	String 		method;

--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,9 @@
+name=ESPWebDAV
+version=1.0.0
+author=ardyesp
+maintainer=ardyesp
+sentence=With this library you can easily build a WebDAV server with your ESP8266 or ESP32.
+paragraph=Read and write data to your SD card from any WebDAV-enabled client on the the network.
+category=Communication
+url=https://github.com/ardyesp/ESPWebDAV
+architectures=esp8266,esp32


### PR DESCRIPTION
in file ESPWebDAV.cpp : 

```
#ifdef USE_SDFAT
	char buf[255];
	curFile->getName(buf, sizeof(buf));
#else
	const char* buf = curFile->name() + 1;
#endif
```

the "+1" schouldn't exist, it change the name of the files and we can not download anymore

it should be 

```
#ifdef USE_SDFAT
	char buf[255];
	curFile->getName(buf, sizeof(buf));
#else
	const char* buf = curFile->name();
#endif
```